### PR TITLE
Closes #5 Prepare repository for releases with github actions and repository dispatch.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,29 +1,26 @@
 name: Create Release
+run-name: Create `${{ github.event.client_payload.version }}` release from `${{ github.ref_name }}` branch.
 on:
   repository_dispatch:
     types: az_icons_release
-
 jobs:
   release:
     name: Create Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ssh-key: ${{ secrets.SELF_DEPLOY_KEY }}
-
       - name: Build variables
         run: echo "AZ_ICONS_CLONE_DIR=az-icons" >> ${GITHUB_ENV}
-
       - name: Get new updates from az-icons
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: az-digital/az-icons
           path: ${{ env.AZ_ICONS_CLONE_DIR }}
           ref: ${{ github.event.client_payload.sha }}
-
       - name: Copy new version of Arizona Icons and commit
         run: |
           distwhitelist='fonts png svg az-icons-styles.css az-icons-styles.min.css'
@@ -37,15 +34,13 @@ jobs:
           git push
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: "v${{ github.event.client_payload.version }}"
-          release_name: "v${{ github.event.client_payload.version }}"
+          name: "v${{ github.event.client_payload.version }}"
           draft: false
-          prerelease: false #${{ contains(env.AZ_VERSION, '-alpha') }}
-
+          prerelease: false
   dispatch:
     needs: release
     strategy:
@@ -55,13 +50,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Get release data
         run: |
           sha=$(git rev-parse HEAD)
           echo "RELEASE_SHA=${sha}" >> ${GITHUB_ENV}
       - name: Notify dependencies
-        uses: peter-evans/repository-dispatch@1708dda5703a768a0fb0ef6a7a03a0c3805ebc59
+        uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.REPO_DISPATCH_TOKEN }}
           repository: ${{ matrix.repo }}


### PR DESCRIPTION
Updating action dependencies:
- https://github.com/actions/checkout to v4
- https://github.com/peter-evans/repository-dispatch to v3

Change
`actions/create-release` to `softprops/action-gh-release`

Use latest ubuntu runner